### PR TITLE
fix: call limiter.makeRequest() instead of original method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,7 +299,7 @@ export class Paginator {
     const stream = limiter.stream;
 
     stream.once('reading', () => {
-      makeRequest(query);
+      limiter.makeRequest(query);
     });
 
     function makeRequest(query?: ParsedArguments|string) {


### PR DESCRIPTION
Should fix failing system-test currently observed in
https://github.com/googleapis/nodejs-bigquery