### PR TITLE
feat: handle promise based functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -314,13 +314,7 @@ export class Paginator {
     });
 
     function makeRequest(query?: ParsedArguments|string) {
-      if (parsedArguments.callback) {
-        originalMethod(query, onResultSet);
-      } else {
-        originalMethod(query).then(
-            // tslint:disable-next-line:no-any
-            (resp: any[]) => onResultSet(null, ...resp), onResultSet);
-      }
+      originalMethod(query, onResultSet);
     }
 
     // tslint:disable-next-line:no-any

--- a/test/index.ts
+++ b/test/index.ts
@@ -532,10 +532,10 @@ describe('paginator', () => {
       before(() => {
         delete PARSED_ARGUMENTS.callback;
       });
-      it('should call original method when stream opens', () => {
-        async function originalMethod(query: {}) {
+      it('should call original method when stream opens', (done) => {
+        function originalMethod(query: {}) {
           assert.strictEqual(query, PARSED_ARGUMENTS.query);
-          return [0];
+          done();
         }
         p.paginator.runAsStream_(PARSED_ARGUMENTS, originalMethod);
       });
@@ -543,8 +543,10 @@ describe('paginator', () => {
       it('should emit an error if one occurs', (done) => {
         const error = new Error('Error.');
 
-        async function originalMethod(query: {}) {
-          throw (error);
+        function originalMethod(query: {}, callback: (err: Error) => void) {
+          setImmediate(() => {
+            callback(error);
+          });
         }
 
         const rs = p.paginator.runAsStream_(PARSED_ARGUMENTS, originalMethod);
@@ -558,8 +560,11 @@ describe('paginator', () => {
         const results = ['a', 'b', 'c'];
         const resultsReceived: Array<{}> = [];
 
-        async function originalMethod(query: {}) {
-          return ([results]);
+        function originalMethod(
+            query: {}, callback: (err: Error|null, results: {}) => void) {
+          setImmediate(() => {
+            callback(null, results);
+          });
         }
 
         const rs = p.paginator.runAsStream_(PARSED_ARGUMENTS, originalMethod);


### PR DESCRIPTION
Paginator will now handle `promise` based functions.

It is a prerequisite for converting libraries to `async` first approach.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
