### PR TITLE
fix: destroy ResourceStream with pre-flight error

### DIFF
--- a/src/resource-stream.ts
+++ b/src/resource-stream.ts
@@ -70,37 +70,37 @@ export class ResourceStream<T> extends Transform implements ResourceEvents<T> {
             this.destroy(err);
             return;
           }
-  
+
           this._nextQuery = nextQuery;
-  
+
           if (this._resultsToSend !== Infinity) {
             results = results.splice(0, this._resultsToSend);
             this._resultsToSend -= results.length;
           }
-  
+
           let more = true;
-  
+
           for (const result of results) {
             if (this._ended) {
               break;
             }
             more = this.push(result);
           }
-  
+
           const isFinished = !this._nextQuery || this._resultsToSend < 1;
           const madeMaxCalls = ++this._requestsMade >= this._maxApiCalls;
-  
+
           if (isFinished || madeMaxCalls) {
             this.end();
           }
-  
+
           if (more && !this._ended) {
             setImmediate(() => this._read());
           }
-  
+
           this._reading = false;
         }
-      ); 
+      );
     } catch (e) {
       this.destroy(e);
     }

--- a/test/resource-stream.ts
+++ b/test/resource-stream.ts
@@ -280,5 +280,17 @@ describe('ResourceStream', () => {
 
       assert.strictEqual(stream._reading, false);
     });
+
+    it('should destroy the stream if the request method throws', done => {
+      const error = new Error('Error.');
+      stream._requestFn = () => {
+        throw error;
+      };
+      stream.on('error', err => {
+        assert.strictEqual(err, error);
+        done();
+      });
+      stream._read()
+    });
   });
 });

--- a/test/resource-stream.ts
+++ b/test/resource-stream.ts
@@ -290,7 +290,7 @@ describe('ResourceStream', () => {
         assert.strictEqual(err, error);
         done();
       });
-      stream._read()
+      stream._read();
     });
   });
 });


### PR DESCRIPTION
RE: https://github.com/googleapis/nodejs-bigquery/issues/707

*(It's easier to view this PR with whitespace changes hidden: https://github.com/googleapis/nodejs-paginator/pull/236/files?diff=unified&w=1)*

In many situations across our APIs, we validate the input from a user to a given method. So, if a user is assembling a query to send off to the API, sometimes we'll figure out that it won't work, and we'll throw before we even attempt the request. For example:

```js
bigQuery.query = (input) => {
  if (input !== validInput) {
    throw Error('Invalid!')
  }
}
```
```js
try {
  bigQuery.query({ ... invalid input ... });
} catch (e) {
  // e.message === "Invalid!"
}
```

Throwing and streams aren't very compatible due to the sync-vs-async nature, so this doesn't work:

```js
bigQuery.createQueryStream = (input) => {
  const userStream = new Stream()

  // ResourceStream doesn't call request methods
  // until the user is actually using the stream.
  //
  // This mocks that scenario to demonstrate that we
  // are now off of the sync flow
  userStream.on('read', () => {
    if (input !== validInput) {
      throw Error('Invalid!')
    }
  })

  return userStream
}
```
```js
try {
  bigQuery.createQueryStream({ ... invalid input ... })
    .on('error', () => {})
    .pipe(...);
} catch (e) {
  // Never fired
}

// Uncaught error is triggered
```

This change will wrap the calls to the request stream in a try/catch, and then destroy the stream with any error that was caught.

```js
bigQuery.createQueryStream({ ... invalid input ... })
  .on('error', (err) => {
    // err.message === 'Invalid!'
  })
  .pipe(...);
```