### PR TITLE
fix: should pass extra callback arguments back to consumer

### DIFF
--- a/src/resource-stream.ts
+++ b/src/resource-stream.ts
@@ -31,6 +31,7 @@ export class ResourceStream<T> extends Transform implements ResourceEvents<T> {
   _ended: boolean;
   _maxApiCalls: number;
   _nextQuery: {} | null;
+  _otherArgs: unknown[];
   _reading: boolean;
   _requestFn: Function;
   _requestsMade: number;
@@ -46,6 +47,7 @@ export class ResourceStream<T> extends Transform implements ResourceEvents<T> {
     this._requestFn = requestFn;
     this._requestsMade = 0;
     this._resultsToSend = args.maxResults === -1 ? Infinity : args.maxResults!;
+    this._otherArgs = [];
   }
   /* eslint-disable  @typescript-eslint/no-explicit-any */
   end(
@@ -67,12 +69,18 @@ export class ResourceStream<T> extends Transform implements ResourceEvents<T> {
     try {
       this._requestFn(
         this._nextQuery,
-        (err: Error | null, results: T[], nextQuery: {} | null) => {
+        (
+          err: Error | null,
+          results: T[],
+          nextQuery: {} | null,
+          ...otherArgs: []
+        ) => {
           if (err) {
             this.destroy(err);
             return;
           }
 
+          this._otherArgs = otherArgs;
           this._nextQuery = nextQuery;
 
           if (this._resultsToSend !== Infinity) {

--- a/test/resource-stream.ts
+++ b/test/resource-stream.ts
@@ -150,6 +150,17 @@ describe('ResourceStream', () => {
       assert.strictEqual(stream._nextQuery, fakeQuery);
     });
 
+    it('should cache the rest of the callback arguments', () => {
+      const fakeRes = {status: 'OK'};
+      const anotherArg = 10;
+
+      stream._read();
+      const callback = requestSpy.lastCall.args[1];
+      callback(null, [], {}, fakeRes, anotherArg);
+
+      assert.deepStrictEqual(stream._otherArgs, [fakeRes, anotherArg]);
+    });
+
     it('should adjust the results to send counter', () => {
       const maxResults = 100;
       const results = [{}, {}];


### PR DESCRIPTION
Towards fixing https://github.com/googleapis/nodejs-bigquery/issues/1210 and https://github.com/googleapis/nodejs-bigquery/issues/1362

