### PR TITLE
build: pin @compodoc/compodoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.7",
+    "@compodoc/compodoc": "1.1.23",
     "@types/extend": "^3.0.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "^20.4.9",


### PR DESCRIPTION
Latest versions of compodoc is failing and following the path of other googleapis libraries, we are going to pin `compodoc` version.

Reference:
* https://github.com/googleapis/google-auth-library-nodejs/pull/1805
