### PR TITLE
fix: query should be on the list of extra args

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,10 +233,10 @@ export class Paginator {
         });
     });
     if (!callback) {
-      return promise.then(results => [results, ...otherArgs]);
+      return promise.then(results => [results, query, ...otherArgs]);
     }
     promise.then(
-      results => callback(null, results, ...otherArgs),
+      results => callback(null, results, query, ...otherArgs),
       (err: Error) => callback(err)
     );
   }

--- a/test/index.ts
+++ b/test/index.ts
@@ -392,10 +392,12 @@ describe('paginator', () => {
             callback(
               err: Error,
               results_: {},
+              query: {},
               fakeRes: {},
               anotherArg: number
             ) {
               assert.deepStrictEqual(results_, results);
+              assert.deepStrictEqual(query, {});
               assert.deepStrictEqual(fakeRes, {msg: 'OK'});
               assert.deepStrictEqual(anotherArg, 10);
               done();
@@ -483,8 +485,9 @@ describe('paginator', () => {
 
           paginator
             .run_(parsedArguments, util.noop)
-            .then(([results_, fakeRes, anotherArg]: unknown[]) => {
+            .then(([results_, query_, fakeRes, anotherArg]: unknown[]) => {
               assert.deepStrictEqual(results_, results);
+              assert.deepStrictEqual(query_, {});
               assert.deepEqual(fakeRes, {msg: 'OK'});
               assert.deepEqual(anotherArg, 10);
             });

--- a/test/index.ts
+++ b/test/index.ts
@@ -397,7 +397,7 @@ describe('paginator', () => {
               anotherArg: number
             ) {
               assert.deepStrictEqual(results_, results);
-              assert.deepStrictEqual(query, {});
+              assert.deepStrictEqual(query, undefined);
               assert.deepStrictEqual(fakeRes, {msg: 'OK'});
               assert.deepStrictEqual(anotherArg, 10);
               done();
@@ -469,7 +469,7 @@ describe('paginator', () => {
             );
         });
 
-        it('should resolve with all results and extra args', () => {
+        it('should resolve with all results and extra args', done => {
           const results = [{a: 1}, {b: 2}, {c: 3}];
           const args: any[] = [{msg: 'OK'}, 10];
 
@@ -487,9 +487,10 @@ describe('paginator', () => {
             .run_(parsedArguments, util.noop)
             .then(([results_, query_, fakeRes, anotherArg]: unknown[]) => {
               assert.deepStrictEqual(results_, results);
-              assert.deepStrictEqual(query_, {});
+              assert.deepStrictEqual(query_, undefined);
               assert.deepEqual(fakeRes, {msg: 'OK'});
               assert.deepEqual(anotherArg, 10);
+              done();
             });
         });
       });


### PR DESCRIPTION
The fix on #361 actually missed passing the `query` within the list of extra args, as on methods returning more than two arguments, the `query` is suppose to be on the list.  

Example with BigQuery:
```
const [rows, q, response] = await bigqueryClient.query(sqlQuery, options)
// rows is the list of items accumulated with rows from all paginated calls
// q is initial Query
// response is the last call Response
```
